### PR TITLE
Implemented #278, fixed an issue that caused SyntaxNode.GetEnclosingT…

### DIFF
--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/Tests/Tests/TestMethodWithoutTestAttributeTests.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/Tests/Tests/TestMethodWithoutTestAttributeTests.cs
@@ -1,0 +1,188 @@
+﻿using System.Data;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RoslynTester.Helpers.CSharp;
+using VSDiagnostics.Diagnostics.Tests.TestMethodWithoutTestAttribute;
+
+namespace VSDiagnostics.Test.Tests.Tests
+{
+    [TestClass]
+    public class TestMethodWithoutTestAttributeTests : CSharpDiagnosticVerifier
+    {
+        protected override DiagnosticAnalyzer DiagnosticAnalyzer => new TestMethodWithoutTestAttributeAnalyzer();
+
+        [TestMethod]
+        public void TestMethodWithoutTestAttribute_MSTest()
+        {
+            var original = @"
+namespace ConsoleApplication1
+{
+    [TestClass]
+    class MyClass
+    {
+        public void MyMethod()
+        {
+        }
+    }
+}";
+
+            VerifyDiagnostic(original, "Method MyMethod might be mistakingly missing a test attribute");
+        }
+
+        [TestMethod]
+        public void TestMethodWithoutTestAttribute_NUnit()
+        {
+            var original = @"
+namespace ConsoleApplication1
+{
+    [TestFixture]
+    class MyClass
+    {
+        public void MyMethod()
+        {
+        }
+    }
+}";
+
+            VerifyDiagnostic(original, "Method MyMethod might be mistakingly missing a test attribute");
+        }
+
+        [TestMethod]
+        public void TestMethodWithoutTestAttribute_XUnit_NoOtherMethodsWithAttribute()
+        {
+            var original = @"
+namespace ConsoleApplication1
+{
+    class MyClass
+    {
+        public void MyMethod()
+        {
+        }
+    }
+}";
+
+            VerifyDiagnostic(original);
+        }
+
+        [TestMethod]
+        public void TestMethodWithoutTestAttribute_XUnit_OtherMethodWithAttribute()
+        {
+            var original = @"
+namespace ConsoleApplication1
+{
+    class MyClass
+    {
+        public void MyMethod()
+        {
+        }
+
+        [Fact]
+        public void MyOtherMethod()
+        {
+        }
+    }
+}";
+
+            VerifyDiagnostic(original, "Method MyMethod might be mistakingly missing a test attribute");
+        }
+
+        [TestMethod]
+        public void TestMethodWithoutTestAttribute_struct()
+        {
+            var original = @"
+namespace ConsoleApplication1
+{
+    [TestClass]
+    struct MyStruct
+    {
+        public void MyMethod()
+        {
+        }
+    }
+}";
+
+            VerifyDiagnostic(original, "Method MyMethod might be mistakingly missing a test attribute");
+        }
+
+        [TestMethod]
+        public void TestMethodWithoutTestAttribute_TaskReturn()
+        {
+            var original = @"
+using System.Threading.Tasks;
+
+namespace ConsoleApplication1
+{
+    [TestClass]
+    class MyClass
+    {
+        public async Task MyMethod()
+        {
+            await Task.Delay(0);
+        }
+    }
+}";
+
+            VerifyDiagnostic(original, "Method MyMethod might be mistakingly missing a test attribute");
+        }
+
+        [TestMethod]
+        public void TestMethodWithoutTestAttribute_TaskTReturn()
+        {
+            var original = @"
+using System.Threading.Tasks;
+
+namespace ConsoleApplication1
+{
+    [TestClass]
+    class MyClass
+    {
+        public Task<int> MyMethod()
+        {
+            return Task.FromResult(5);
+        }
+    }
+}";
+
+            VerifyDiagnostic(original, "Method MyMethod might be mistakingly missing a test attribute");
+        }
+
+        [TestMethod]
+        public void TestMethodWithoutTestAttribute_OtherReturnType()
+        {
+            var original = @"
+namespace ConsoleApplication1
+{
+    [TestClass]
+    class MyClass
+    {
+        public int MyMethod()
+        {
+            return 5;
+        }
+    }
+}";
+
+            VerifyDiagnostic(original);
+        }
+
+        [TestMethod]
+        public void TestMethodWithoutTestAttribute_OtherAttribute()
+        {
+            var original = @"
+namespace ConsoleApplication1
+{
+    [TestClass]
+    class MyClass
+    {
+        [SomethingElse]
+        public int MyMethod()
+        {
+            return 5;
+        }
+    }
+}";
+
+            VerifyDiagnostic(original);
+        }
+    }
+}

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/VSDiagnostics.Test.csproj
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/VSDiagnostics.Test.csproj
@@ -153,6 +153,7 @@
     <Compile Include="Tests\Tests\RemoveTestSuffixTests.cs" />
     <Compile Include="Tests\Tests\TestMethodWithoutPublicModifierTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Tests\Tests\TestMethodWithoutTestAttributeTests.cs" />
     <Compile Include="Tests\Utilities\ExtensionsTests.cs" />
     <Compile Include="Tests\Utilities\NamingConventionsTests.cs" />
   </ItemGroup>

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Attributes/OnPropertyChangedWithoutCallerMemberName/OnPropertyChangedWithoutCallerMemberNameAnalyzer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Attributes/OnPropertyChangedWithoutCallerMemberName/OnPropertyChangedWithoutCallerMemberNameAnalyzer.cs
@@ -33,6 +33,11 @@ namespace VSDiagnostics.Diagnostics.Attributes.OnPropertyChangedWithoutCallerMem
         {
             var methodDeclaration = (MethodDeclarationSyntax)context.Node;
             var parentNode = methodDeclaration.GetEnclosingTypeNode();
+            if (!parentNode.IsKind(SyntaxKind.StructDeclaration) && !parentNode.IsKind(SyntaxKind.ClassDeclaration))
+            {
+                return;
+            }
+
             var typeSymbol = (INamedTypeSymbol)context.SemanticModel.GetDeclaredSymbol(parentNode);
 
             // class must implement INotifyPropertyChanged

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/General/RedundantPrivateSetter/RedundantPrivateSetterAnalyzer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/General/RedundantPrivateSetter/RedundantPrivateSetterAnalyzer.cs
@@ -52,8 +52,13 @@ namespace VSDiagnostics.Diagnostics.General.RedundantPrivateSetter
             // Since SymbolFinder does not work in an analyzer, we have to simulate finding the symbol ourselves
             // We can do this by getting the inner-most class declaration and then looking at all of its descendants
             // This is a fairly intensive operation but I'm not aware of any alternative
-            var classDeclaration = setAccessor.GetEnclosingTypeNode();
-            var classSymbol = context.SemanticModel.GetDeclaredSymbol(classDeclaration);
+            var enclosingTypeNode = setAccessor.GetEnclosingTypeNode();
+            if (!enclosingTypeNode.IsKind(SyntaxKind.StructDeclaration) && !enclosingTypeNode.IsKind(SyntaxKind.ClassDeclaration))
+            {
+                return;
+            }
+
+            var classSymbol = context.SemanticModel.GetDeclaredSymbol(enclosingTypeNode);
             var propertySymbol = context.SemanticModel.GetDeclaredSymbol(property);
 
             foreach (var partialDeclaration in classSymbol.DeclaringSyntaxReferences)

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Tests/RemoveTestSuffix/RemoveTestSuffixAnalyzer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Tests/RemoveTestSuffix/RemoveTestSuffixAnalyzer.cs
@@ -24,44 +24,22 @@ namespace VSDiagnostics.Diagnostics.Tests.RemoveTestSuffix
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
         public override void Initialize(AnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeNode, SyntaxKind.MethodDeclaration);
-
+            
         private void AnalyzeNode(SyntaxNodeAnalysisContext context)
         {
             var method = (MethodDeclarationSyntax) context.Node;
-
+            
             if (!method.Identifier.Text.EndsWith("Test", StringComparison.CurrentCultureIgnoreCase))
             {
                 return;
             }
 
-            if (!IsTestMethod(method))
+            if (!method.HasTestAttribute())
             {
                 return;
             }
 
             context.ReportDiagnostic(Diagnostic.Create(Rule, method.Identifier.GetLocation(), method.Identifier.Text));
-        }
-
-        private static bool IsTestMethod(MethodDeclarationSyntax method)
-        {
-            var methodAttributes = new[] { "Test", "TestMethod", "Fact" };
-            var attributes = method.AttributeLists.FirstOrDefault()?.Attributes;
-
-            if (attributes == null)
-            {
-                return false;
-            }
-
-            foreach (var attribute in attributes.Value)
-            {
-                var attributeName = attribute.Name.ToString();
-                if (methodAttributes.Contains(attributeName))
-                {
-                    return true;
-                }
-            }
-
-            return false;
         }
     }
 }

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Tests/TestHelpers.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Tests/TestHelpers.cs
@@ -1,0 +1,31 @@
+﻿using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace VSDiagnostics.Diagnostics.Tests
+{
+    internal static class TestHelpers
+    {
+        private static readonly string[] MethodAttributes = { "Test", "TestMethod", "Fact" };
+
+        internal static bool HasTestAttribute(this MethodDeclarationSyntax method)
+        {
+            var attributes = method.AttributeLists.FirstOrDefault()?.Attributes;
+
+            if (attributes == null)
+            {
+                return false;
+            }
+
+            foreach (var attribute in attributes.Value)
+            {
+                var attributeName = attribute.Name.ToString();
+                if (MethodAttributes.Contains(attributeName))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Tests/TestMethodWithoutPublicModifier/TestMethodWithoutPublicModifierAnalyzer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Tests/TestMethodWithoutPublicModifier/TestMethodWithoutPublicModifierAnalyzer.cs
@@ -28,34 +28,11 @@ namespace VSDiagnostics.Diagnostics.Tests.TestMethodWithoutPublicModifier
         {
             var method = (MethodDeclarationSyntax) context.Node;
 
-            if (IsTestMethod(method) && !method.Modifiers.Any(SyntaxKind.PublicKeyword))
+            if (method.HasTestAttribute() && !method.Modifiers.Any(SyntaxKind.PublicKeyword))
             {
                 context.ReportDiagnostic(Diagnostic.Create(Rule, method.Identifier.GetLocation(),
                     method.Identifier.Text));
             }
-        }
-
-        private static bool IsTestMethod(MethodDeclarationSyntax method)
-        {
-            var methodAttributes = new[] { "Test", "TestMethod", "Fact" };
-            var attributes = method.AttributeLists.FirstOrDefault()?.Attributes;
-
-            if (attributes == null)
-            {
-                return false;
-            }
-
-            foreach (var attribute in attributes.Value)
-            {
-                var attributeName = attribute.Name.ToString();
-
-                if (methodAttributes.Contains(attributeName))
-                {
-                    return true;
-                }
-            }
-
-            return false;
         }
     }
 }

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Tests/TestMethodWithoutTestAttribute/TestMethodWithoutTestAttributeAnalyzer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Diagnostics/Tests/TestMethodWithoutTestAttribute/TestMethodWithoutTestAttributeAnalyzer.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using VSDiagnostics.Utilities;
+
+namespace VSDiagnostics.Diagnostics.Tests.TestMethodWithoutTestAttribute
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class TestMethodWithoutTestAttributeAnalyzer : DiagnosticAnalyzer
+    {
+        private const DiagnosticSeverity Severity = DiagnosticSeverity.Warning;
+
+        private static readonly string Category = VSDiagnosticsResources.TestsCategory;
+        private static readonly string Message = VSDiagnosticsResources.TestMethodWithoutTestAttributeAnalyzerMessage;
+        private static readonly string Title = VSDiagnosticsResources.TestMethodWithoutTestAttributeAnalyzerTitle;
+        private static DiagnosticDescriptor Rule => new DiagnosticDescriptor(DiagnosticId.TestMethodWithoutTestAttribute, Title, Message, Category, Severity, true);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context) => context.RegisterSyntaxNodeAction(AnalyzeNode, SyntaxKind.MethodDeclaration);
+
+        private void AnalyzeNode(SyntaxNodeAnalysisContext context)
+        {
+            var method = (MethodDeclarationSyntax) context.Node;
+            
+            // Check if we're in a unit-test context
+            // For NUnit and MSTest we can see if the enclosing class/struct has a [TestClass] or [TestFixture] attribute
+            // For xUnit.NET we will have to see if there are other methods in the current class that contain a [Fact] attribute
+
+            var enclosingType = method.GetEnclosingTypeNode();
+            if (!enclosingType.IsKind(SyntaxKind.ClassDeclaration) && !enclosingType.IsKind(SyntaxKind.StructDeclaration))
+            {
+                return;
+            }
+
+            var symbol = context.SemanticModel.GetDeclaredSymbol(enclosingType) as INamedTypeSymbol;
+            if (symbol == null)
+            {
+                return;
+            }
+
+            var isTestClass = false;
+            foreach (var attribute in symbol.GetAttributes())
+            {
+                if (attribute.AttributeClass.Name == "TestClass" || attribute.AttributeClass.Name == "TestFixture")
+                {
+                    isTestClass = true;
+                    break;
+                }
+            }
+
+            // If it has different attributes then we won't bother with it either
+            if (method.AttributeLists.SelectMany(x => x.Attributes).Any())
+            {
+                return;
+            }
+
+            if (!isTestClass)
+            {
+                // Look at other methods in the class to see if they have a test attribute
+                // We do this only for xUnit.NET because the others should already have been caught with the previous test
+                // If they weren't, it means the entire class wasn't marked as a test which is not in the scope of this analyzer
+
+                foreach (var member in enclosingType.DescendantNodes().OfType<MethodDeclarationSyntax>(SyntaxKind.MethodDeclaration))
+                {
+                    foreach (var attributeList in member.AttributeLists)
+                    {
+                        foreach (var attribute in attributeList.Attributes)
+                        {
+                            if (attribute.Name.ToString() == "Fact" || attribute.Name.ToString() == "Theory")
+                            {
+                                isTestClass = true;
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (!isTestClass)
+            {
+                return;
+            }
+
+            var returnType = context.SemanticModel.GetTypeInfo(method.ReturnType).Type;
+            var voidType = context.SemanticModel.Compilation.GetSpecialType(SpecialType.System_Void);
+            var taskType = context.SemanticModel.Compilation.GetTypeByMetadataName("System.Threading.Tasks.Task");
+            var taskTType = context.SemanticModel.Compilation.GetTypeByMetadataName("System.Threading.Tasks.Task`1");
+            if (!(returnType.Equals(voidType) || returnType.Equals(taskType) || returnType.OriginalDefinition.Equals(taskTType)))
+            {
+                return;
+            }
+
+            context.ReportDiagnostic(Diagnostic.Create(Rule, method.Identifier.GetLocation(), method.Identifier));
+        }
+    }
+}

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Utilities/DiagnosticId.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Utilities/DiagnosticId.cs
@@ -61,5 +61,6 @@
         public const string ExceptionThrownFromFinalizer = "VSD0058";
         public const string ExceptionThrownFromGetHashCode = "VSD0059";
         public const string ExceptionThrownFromEquals = "VSD0060";
+        public const string TestMethodWithoutTestAttribute = "VSD0062";
     }
 }

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/Utilities/Extensions.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/Utilities/Extensions.cs
@@ -247,11 +247,17 @@ namespace VSDiagnostics.Utilities
             return identifier != null && identifier.Identifier.ValueText == "nameof";
         }
 
+        /// <summary>
+        /// Gets the innermost surrounding class, struct or interface declaration
+        /// </summary>
+        /// <param name="syntaxNode">The node to start from</param>
+        /// <returns>The surrounding declaration node</returns>
+        /// <exception cref="ArgumentException">Thrown when there is no surrounding class, struct or interface declaration"/></exception>
         public static SyntaxNode GetEnclosingTypeNode(this SyntaxNode syntaxNode)
         {
             foreach (var ancestor in syntaxNode.AncestorsAndSelf())
             {
-                if (ancestor.IsKind(SyntaxKind.ClassDeclaration) || ancestor.IsKind(SyntaxKind.StructDeclaration))
+                if (ancestor.IsKind(SyntaxKind.ClassDeclaration) || ancestor.IsKind(SyntaxKind.StructDeclaration) || ancestor.IsKind(SyntaxKind.InterfaceDeclaration))
                 {
                     return ancestor;
                 }

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/VSDiagnostics.csproj
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/VSDiagnostics.csproj
@@ -118,8 +118,10 @@
     <Compile Include="Diagnostics\Structs\StructWithoutElementaryMethodsOverridden\StructWithoutElementaryMethodsOverriddenCodeFix.cs" />
     <Compile Include="Diagnostics\Tests\RemoveTestSuffix\RemoveTestSuffixAnalyzer.cs" />
     <Compile Include="Diagnostics\Tests\RemoveTestSuffix\RemoveTestSuffixCodeFix.cs" />
+    <Compile Include="Diagnostics\Tests\TestHelpers.cs" />
     <Compile Include="Diagnostics\Tests\TestMethodWithoutPublicModifier\TestMethodWithoutPublicModifierAnalyzer.cs" />
     <Compile Include="Diagnostics\Tests\TestMethodWithoutPublicModifier\TestMethodWithoutPublicModifierCodeFix.cs" />
+    <Compile Include="Diagnostics\Tests\TestMethodWithoutTestAttribute\TestMethodWithoutTestAttributeAnalyzer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Utilities\DiagnosticId.cs" />
     <Compile Include="Utilities\Extensions.cs" />

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/VSDiagnosticsResources.Designer.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/VSDiagnosticsResources.Designer.cs
@@ -1394,6 +1394,24 @@ namespace VSDiagnostics {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Method {0} might be mistakingly missing a test attribute.
+        /// </summary>
+        internal static string TestMethodWithoutTestAttributeAnalyzerMessage {
+            get {
+                return ResourceManager.GetString("TestMethodWithoutTestAttributeAnalyzerMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A method might be missing a test attribute..
+        /// </summary>
+        internal static string TestMethodWithoutTestAttributeAnalyzerTitle {
+            get {
+                return ResourceManager.GetString("TestMethodWithoutTestAttributeAnalyzerTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Tests.
         /// </summary>
         internal static string TestsCategory {

--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics/VSDiagnosticsResources.resx
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics/VSDiagnosticsResources.resx
@@ -537,7 +537,7 @@
   </data>
   <data name="RedundantPrivateSetterCodeFixTitle" xml:space="preserve">
     <value>Turn into a read-only property</value>
-    </data>
+  </data>
   <data name="ElementaryMethodsOfTypeInCollectionNotOverriddenAnalyzerMessage" xml:space="preserve">
     <value>Implement elementary methods of type used in collection.</value>
   </data>
@@ -637,5 +637,12 @@
   </data>
   <data name="ExceptionThrownFromStaticConstructorAnalyzerTitle" xml:space="preserve">
     <value>An exception is thrown from a static constructor.</value>
+  </data>
+  <data name="TestMethodWithoutTestAttributeAnalyzerMessage" xml:space="preserve">
+    <value>Method {0} might be mistakingly missing a test attribute</value>
+    <comment>{0} - Method name</comment>
+  </data>
+  <data name="TestMethodWithoutTestAttributeAnalyzerTitle" xml:space="preserve">
+    <value>A method might be missing a test attribute.</value>
   </data>
 </root>


### PR DESCRIPTION
…ypeNode() to throw an exception because the node is contained in an interface and fixed #579