### PR TITLE
Added test that verifies a delegate without type doesn't crash TypeToVar

### DIFF
--- a/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/Tests/General/TypeToVarTests.cs
+++ b/VSDiagnostics/VSDiagnostics/VSDiagnostics.Test/Tests/General/TypeToVarTests.cs
@@ -280,5 +280,26 @@ namespace ConsoleApplication1
 
             VerifyDiagnostic(original);
         }
+
+        [TestMethod]
+        public void TypeToVar_WithLambdaExpression_NoType()
+        {
+            var original = @"
+using System;
+using System.Text;
+
+namespace ConsoleApplication1
+{
+    class MyClass
+    {   
+        void Method()
+        {
+            Action x = () => { };
+        }
+    }
+}";
+
+            VerifyDiagnostic(original);
+        }
     }
 }


### PR DESCRIPTION
Fixes #586 